### PR TITLE
Refactor schema validation into it's own command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,17 @@ exclude = '''
   | settings.py
 )
 '''
+
+[tool.jsonschema_testing]
+schema_file_extension = ".json"
+schema_exclude_filenames = []
+instance_file_extension = ".yml"
+schema_search_directory = "./examples/schema/json/full_schemas/"
+instance_exclude_filenames = ['.yamllint.yml', '.travis.yml']
+schema_file_type = "json"
+instance_search_directory = "./examples/hostvars/"
+instance_file_type = "yaml"
+
+schema_mapping."dns.yml" = ['dns.json']
+schema_mapping.'ntp.yml' = ["dns.json"]
+schema_mapping.'syslog.yml' = ["syslog.json"]


### PR DESCRIPTION
- This was defined in the main function before. Because main became
  decorated with `click.group()` it was no longer executed when the
  script was called without commands/options. The code for executing
  schema validation was moved to the validate_schema() function and
  decorated correctly using click so that it can execute when run as
  a command. Likewise, it was moved out of main.
- pyproject.toml has been updated with jsonschema_testing config options.
  test_schema.py has also been updated to parse those options
- A series of TODO statements have been added to test_schema to indicate
  work which needs to be done.