### PR TITLE
Update configuration.md doc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,15 +20,16 @@ schema_directory = "schemas"
 test_directory = "tests"
 
 # Settings specific to the schema files
-schema_file_extensions [".json", ".yaml", ".yml"]
 schema_file_exclude_filenames = []
 
 # settings specific to search and identify all instance file to validate
-instance_search_directories = ["./"]
-instance_file_extensions = [".json", ".yaml", ".yml"]
-instance_file_exclude_filenames = [".yamllint.yml", ".travis.yml"]
+data_file_search_directories = ["./"]
+data_file_extensions = [".json", ".yaml", ".yml"]
+data_file_exclude_filenames = [".yamllint.yml", ".travis.yml"]
 
 ansible_inventory = None
+
+[tools.schema_enforcer.schema_mapping]
 ```
 
 ### Overriding the Default Configuration
@@ -40,9 +41,11 @@ The table below enumerates each individual setting, it's expected type, it's def
 | main_directory | string | "schema" | The directory in which to start searching for schema and definition files |
 | definition_directory | string | "definitions" | The directory in which to search for schema definition references. These definitions are can be referenced by the schema files in the "schema_directory". This directory should be nested in the "main_directory" |
 | schema_directory | string | "schemas" | The directory in which to search for schemas. This directory should be nested in the "main_directory" |
-| test_directory | string | "tests" | TODO |
+| test_directory | string | "tests" | The directory in which to search for valid and invalid unit tests for schemas |
 | schema_file_extensions | list | [".json", ".yaml", ".yml"] | The extensions to use when searching for schema definition files |
 | schema_file_exclude_filenames | list | [] | The list of filenames to exclude when searching for schema files in the `schema_directory` directory |
-| instance_search_directories | list | ["./"] The paths at which to start searching for files with structured data in them to validate against defined schemas. This path is relative to the directory in which `schema-enforcer` is executed.
-| instance_file_extensions | list | [".json", ".yaml", ".yml"] | The extensions to use when searching for structured data files |
-| instance_file_exclude_filenames | list | [".yamllint.yml", ".travis.yml"] | The list of filenames to exclude when searching for structured data files |
+| data_file_search_directories | list | ["./"] The paths at which to start searching for files with structured data in them to validate against defined schemas. This path is relative to the directory in which `schema-enforcer` is executed.
+| data_file_extensions | list | [".json", ".yaml", ".yml"] | The extensions to use when searching for structured data files |
+| data_file_exclude_filenames | list | [".yamllint.yml", ".travis.yml"] | The list of filenames to exclude when searching for structured data files |
+| ansible_inventory | str | None | The ansible inventory file to use when building an inventory of hosts against which to check for schema adherence |
+| schema_mapping | dict | {} | A mapping of structured data file names (keys) to lists of schema IDs (values) against which the data file should be checked for adherence |


### PR DESCRIPTION
This PR updates the configuration.md doc to reflect the name change from "instance_file" to "data_file", and with it, configuration parameters which were modified in the pydantic settings but missed in the documentation.

`schema_file_extensions` has been removed as a configuration parameter as it is defined by pydantic but not actually in use by the tool, and there's a question open as to whether we actually want to implement the functionality or not.