### PR TITLE
Optimize container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   matrix:
     - "ANSIBLE_VER=2.8.20 ANSIBLE_PACKAGE=ansible"
     - "ANSIBLE_VER=2.9.20 ANSIBLE_PACKAGE=ansible"
+    - "ANSIBLE_VER=2.10.7 ANSIBLE_PACKAGE=ansible"
     - "ANSIBLE_VER=2.10.8 ANSIBLE_PACKAGE=ansible-base"
 before_script:
   - "pip install invoke toml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 stages:
   - name: "lint"
   - name: "test"
-  - name: "test-without-ansible"
   - name: "deploy-github"
     if: "tag IS present"
   - name: "deploy-pypi"
@@ -21,9 +20,9 @@ services:
 # Env, before_script, and script for test stage
 env:
   matrix:
-    - "ANSIBLE_VER=2.8.20"
-    - "ANSIBLE_VER=2.9.20"
-    - "ANSIBLE_VER=2.10.7"
+    - "ANSIBLE_VER=2.8.20 ANSIBLE_PACKAGE=ansible"
+    - "ANSIBLE_VER=2.9.20 ANSIBLE_PACKAGE=ansible"
+    - "ANSIBLE_VER=2.10.8 ANSIBLE_PACKAGE=ansible-base"
 before_script:
   - "pip install invoke toml"
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,9 @@ RUN poetry config virtualenvs.create false \
   && poetry install --no-interaction --no-ansi
 
 # -----------------------------------------------------------------------------
-# Defines stage with ansible installed
-# -----------------------------------------------------------------------------
-FROM base as with_ansible
-ARG ANSIBLE_VER
-RUN pip install ansible==$ANSIBLE_VER
-
-# -----------------------------------------------------------------------------
 # Defines stage with ansible-base installed
 # -----------------------------------------------------------------------------
-FROM base as with_ansible_base
-ARG ANSIBLE_BASE_VER
-RUN pip install ansible-base==$ANSIBLE_BASE_VER
+FROM base as with_ansible
+ARG ANSIBLE_PACKAGE
+ARG ANSIBLE_VER
+RUN pip install $ANSIBLE_PACKAGE==$ANSIBLE_VER

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN poetry config virtualenvs.create false \
   && poetry install --no-interaction --no-ansi
 
 # -----------------------------------------------------------------------------
-# Defines stage with ansible-base installed
+# Defines stage with ansible installed
 # -----------------------------------------------------------------------------
 FROM base as with_ansible
 ARG ANSIBLE_PACKAGE


### PR DESCRIPTION
## What this does

This PR optimizes container builds and testing in the following way:

1) Collapses the `with_ansible_base` stage in the Dockerfile into the `with_ansible` stage.
2) Allows for the definition of an `ANSIBLE_PACKAGE` environment variable. In constructing the containers for tests, invoke will read this variable to determine whether the `with_ansible` container should use `ansible` or `ansible-base` for its build. The default is `ansible-base` with a version of `2.10.8` if the user doesn't toggle these vars.
3) Simplifies the docker file and invoke tasks to make use of these vars.

## Why

Using a single Ansible container and toggling the package type/version with environment variables to define what kind/version of ansible is installed in it simplifies the invoke tasks and speeds up build time.