### PR TITLE
Resolve issue with --generate-invalid and --check for invalid tests

### DIFF
--- a/schema_enforcer/schemas/manager.py
+++ b/schema_enforcer/schemas/manager.py
@@ -202,6 +202,7 @@ class SchemaManager:
 
         results = []
         for test_dir in test_dirs:
+            schema.clear_results()
             data_file = find_file(os.path.join(invalid_test_dir, test_dir, "data"))
             expected_results_file = find_file(os.path.join(invalid_test_dir, test_dir, "results"))
 
@@ -263,7 +264,7 @@ class SchemaManager:
 
         # For each test, load the data file, test the data against the schema and save the results
         for test_dir in test_dirs:
-
+            schema.clear_results()
             data_file = find_file(os.path.join(invalid_test_dir, test_dir, "data"))
 
             if not data_file:

--- a/tests/fixtures/test_manager/invalid_generate/schema/schemas/test.yml
+++ b/tests/fixtures/test_manager/invalid_generate/schema/schemas/test.yml
@@ -1,0 +1,25 @@
+---
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "schemas/test"
+description: "NFTables Firewall Configuration schema."
+type: "object"
+properties:
+  firewall:
+    type: "object"
+    uniqueItems: true
+    additionalProperties: false
+    required:
+      - "rule"
+      - "variables"
+    properties:
+      rule:
+        type: "object"
+        properties:
+          bool:
+            type: "boolean"
+          Text:
+            type: "string"
+          dict:
+            type: "object"
+      variables:
+        type: "object"

--- a/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type1/data.json
+++ b/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type1/data.json
@@ -1,0 +1,13 @@
+{
+    "firewall": {
+        "rule": {
+            "bool": "true",
+            "Text": "text",
+            "dict": {}
+        },
+        "variables": {
+            "Text": "text",
+            "array": []
+        }
+    }
+}

--- a/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type1/exp_results.yml
+++ b/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type1/exp_results.yml
@@ -1,0 +1,9 @@
+---
+results:
+  - result: "FAIL"
+    schema_id: "schemas/test"
+    absolute_path:
+      - "firewall"
+      - "rule"
+      - "bool"
+    message: "'true' is not of type 'boolean'"

--- a/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type2/data.json
+++ b/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type2/data.json
@@ -1,0 +1,13 @@
+{
+    "firewall": {
+        "rule": {
+            "bool": true,
+            "Text": 123,
+            "dict": {}
+        },
+        "variables": {
+            "Text": "text",
+            "array": {}
+        }
+    }
+}

--- a/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type2/exp_results.yml
+++ b/tests/fixtures/test_manager/invalid_generate/schema/tests/test/invalid/invalid_type2/exp_results.yml
@@ -1,0 +1,9 @@
+---
+results:
+  - result: "FAIL"
+    schema_id: "schemas/test"
+    absolute_path:
+      - "firewall"
+      - "rule"
+      - "Text"
+    message: "123 is not of type 'string'"

--- a/tests/fixtures/test_manager/invalid_generate/schema/tests/test/valid/test.json
+++ b/tests/fixtures/test_manager/invalid_generate/schema/tests/test/valid/test.json
@@ -1,0 +1,13 @@
+{
+    "firewall": {
+        "rule": {
+            "bool": true,
+            "Text": "text",
+            "dict": {}
+        },
+        "variables": {
+            "Text": "text",
+            "array": []
+        }
+    }
+}


### PR DESCRIPTION
Fixes #103 

This issue was introduced after migrating `JsonSchema` to be a sub-class of `BaseValidation`. Since results are now cached for each validator instance, the `--generate-invalid` command could generate result files with multiple values. Additionally, `test_schema_invalid` also experiences an issue due to the results caching and requires they be cleared in between runs.